### PR TITLE
Update main.yml

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,23 +39,23 @@
 - set_fact:
     expire_value: |
       {{ chage.stdout_lines[3].split(':')[1] }}
-  when: not chage|skipped
+  when: chage is not skipped
 
 - debug: { var: expire_value }
-  when: not chage|skipped and debug|default(False)
+  when: chage is not skipped and debug|default(False)
 
 - set_fact:
     expire_date: |
       {{ lookup('pipe', 'date +%F -d' + expire_value | quote) }}
-  when: not chage|skipped and not expire_value.find('never') != -1
+  when: chage is not skipped and not expire_value.find('never') != -1
 
 - debug: { var: expire_date }
-  when: not chage|skipped and debug|default(False)
+  when: chage is not skipped and debug|default(False)
 
 - name: disable user
 
-  when:    (not chage|skipped and not expire_value.find('never') != -1 and expire_date != expire|string)
-        or (not chage|skipped and     expire_value.find('never') != -1)
+  when:    (chage is not skipped and not expire_value.find('never') != -1 and expire_date != expire|string)
+        or (chage is not skipped and     expire_value.find('never') != -1)
 
   command: chage -E {{ expire }} {{ user }}
 


### PR DESCRIPTION
Changes `not chage|skipped` to `chage is not skipped` to avoid deprecated messages from Ansible on 2.7 version.